### PR TITLE
[SCAL-77375] UI polishing fixes

### DIFF
--- a/docs/src/components/BackButton/index.scss
+++ b/docs/src/components/BackButton/index.scss
@@ -19,6 +19,6 @@
     }
     p {
         color: $darkgrey;
-        font-size: 14px;
+        font-size: $font-size-normal;
     }
 }

--- a/docs/src/components/Button/index.scss
+++ b/docs/src/components/Button/index.scss
@@ -1,7 +1,7 @@
 @import '../../static/styles/variables.scss';
 
 .button {
-    font-size: 12px;
+    font-size: $font-size-small;
     line-height: $line-height-button;
     letter-spacing: 0.6px;
     padding: 5px 16px;

--- a/docs/src/components/Button/index.scss
+++ b/docs/src/components/Button/index.scss
@@ -2,7 +2,7 @@
 
 .button {
     font-size: 12px;
-    line-height: 16px;
+    line-height: $line-height-button;
     letter-spacing: 0.6px;
     padding: 5px 16px;
     min-width: 75px;

--- a/docs/src/components/Docmap/index.scss
+++ b/docs/src/components/Docmap/index.scss
@@ -6,7 +6,7 @@
     border-left: 1px $lightgrey solid;
     position: fixed;
     right: 0;
-    font-size: 14px;
+    font-size: $font-size-normal;
     height: 100vh;
     overflow-y: auto;
 

--- a/docs/src/components/Docmap/index.scss
+++ b/docs/src/components/Docmap/index.scss
@@ -14,7 +14,7 @@
         padding-left: 40px;
         margin: 0;
         color: $disabledcolor;
-        line-height: 31px;
+        line-height: $line-height-normal;
     }
 
     div {
@@ -22,7 +22,7 @@
             margin-top: 0px;
             list-style-type: none;
             li {
-                line-height: 31px;
+                line-height: $line-height-normal;
     
                 a {
                     color: $primarycolor;

--- a/docs/src/components/Docmap/index.scss
+++ b/docs/src/components/Docmap/index.scss
@@ -14,15 +14,15 @@
         padding-left: 40px;
         margin: 0;
         color: $disabledcolor;
-        margin-bottom: 7px;
+        line-height: 31px;
     }
 
     div {
         ul {
-            margin-top: 2px;
+            margin-top: 0px;
             list-style-type: none;
             li {
-                padding: 7px 0;
+                line-height: 31px;
     
                 a {
                     color: $primarycolor;

--- a/docs/src/components/Document/index.scss
+++ b/docs/src/components/Document/index.scss
@@ -12,7 +12,7 @@
     p {
         font-weight: $font-weight-normal;
         font-size: 16px;
-        line-height: 1.6rem;
+        line-height: $line-height-doc;
     }
 
     img {

--- a/docs/src/components/Document/index.scss
+++ b/docs/src/components/Document/index.scss
@@ -11,7 +11,7 @@
 
     p {
         font-weight: $font-weight-normal;
-        font-size: 16px;
+        font-size: $font-size-doc;
         line-height: $line-height-doc;
     }
 
@@ -41,7 +41,7 @@
     #preview-in-playground {
         background: #2770ef;
         color: white;
-        font-size: 14px;
+        font-size: $font-size-normal;
         font-weight: 300;
         padding: 5px 10px;
         border: 0;

--- a/docs/src/components/Document/index.scss
+++ b/docs/src/components/Document/index.scss
@@ -11,10 +11,41 @@
 
     p {
         font-weight: $font-weight-normal;
+        font-size: 16px;
+        line-height: 1.6rem;
     }
 
     img {
         width: 100%;
+    }
+
+    pre.highlight {
+        white-space: pre-wrap;
+        background: #F8F8F8;
+        padding: 20px 10px;
+    }
+
+    code[data-lang] {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    code[data-lang]::after {
+        content: attr(data-lang);
+        text-transform: uppercase;
+        color: $darkgrey;
+        position: relative;
+        top: -10px;
+    }
+
+    #preview-in-playground {
+        background: #2770ef;
+        color: white;
+        font-size: 14px;
+        font-weight: 300;
+        padding: 5px 10px;
+        border: 0;
+        border-radius: 2px;
     }
 }
 

--- a/docs/src/components/LeftSidebar/index.scss
+++ b/docs/src/components/LeftSidebar/index.scss
@@ -14,14 +14,14 @@ aside {
     .heading {
         padding: 39px 0px 26px 24px;
         margin: 0;
-        font-size: 18px;
+        font-size: $font-size-large;
     }
 
     .subHeading {
         margin: $gutter;
         padding-bottom: 10px;
         padding-left: 24px;
-        font-size: 14px;
+        font-size: $font-size-normal;
     }
 
     ul {
@@ -141,7 +141,7 @@ aside {
     }
 
     a {
-        font-size: 14px;
+        font-size: $font-size-normal;
         font-weight: $font-weight-normal;
         line-height: $line-height-normal;
         width: 100%;

--- a/docs/src/components/LeftSidebar/index.scss
+++ b/docs/src/components/LeftSidebar/index.scss
@@ -2,7 +2,7 @@
 @import '../../static/styles/variables.scss';
 
 aside {
-    width: 260px;
+    width: 310px;
     border-right: 1px $lightgrey solid;
     padding-top: 24px;
     padding-bottom: 24px;
@@ -47,6 +47,14 @@ aside {
                         color: $primarycolor;
                         font-weight: $font-weight-bold;
                         padding-right: 5px;
+
+                        &:visited {
+                            color: $secondarycolor;
+                        }
+
+                        &:active {
+                            color: $secondarycolor;
+                        }
                     }
                 }
 
@@ -70,6 +78,14 @@ aside {
 
                         &:hover {
                             background: $hovercolor;
+                            color: $secondarycolor;
+                        }
+
+                        &:visited {
+                            color: $secondarycolor;
+                        }
+
+                        &:active {
                             color: $secondarycolor;
                         }
                     }
@@ -139,6 +155,6 @@ aside {
 
 @media screen and (min-width: 767px) and (max-width: 1024px) {
     aside {
-        width: 210px;
+        width: 260px;
     }
 }

--- a/docs/src/components/LeftSidebar/index.scss
+++ b/docs/src/components/LeftSidebar/index.scss
@@ -65,7 +65,7 @@ aside {
                         color: $primarycolor;
                         padding-right: 5px;
                         margin: 5px 0;
-                        line-height: 32px;
+                        line-height: $line-height-normal;
 
                         & > a {
                             color: $primarycolor;
@@ -118,7 +118,7 @@ aside {
                             color: $primarycolor;
                             padding-right: 5px;
                             margin: 5px 0;
-                            line-height: 32px;
+                            line-height: $line-height-normal;
     
                             & > a {
                                 color: $primarycolor;
@@ -143,7 +143,7 @@ aside {
     a {
         font-size: 14px;
         font-weight: $font-weight-normal;
-        line-height: 32px;
+        line-height: $line-height-normal;
         width: 100%;
         display: inline-block;
     }

--- a/docs/src/components/Page404/index.scss
+++ b/docs/src/components/Page404/index.scss
@@ -1,3 +1,5 @@
+@import '../../static/styles/variables.scss';
+
 .pageStyles {
   color: #232129;
   padding: 96px;
@@ -18,6 +20,6 @@
   color: #8A6534;
   padding: 4;
   background-color: #FFF4DB;
-  font-size: 1.25rem;
+  font-size: $font-size-404;
   border-radius: 4;
 }

--- a/docs/src/components/Search/index.scss
+++ b/docs/src/components/Search/index.scss
@@ -28,7 +28,7 @@
         border-radius: 6px;
         height: 32px;
         padding-left: 36px;
-        font-size: 14px;
+        font-size: $font-size-normal;
         color: $darkgrey;
     }
 

--- a/docs/src/static/styles/index.scss
+++ b/docs/src/static/styles/index.scss
@@ -24,7 +24,7 @@ body {
     margin: $gutter;
     padding: $gutter;
     font-family: 'Optimo-Plain';
-    font-size: 14px;
+    font-size: $font-size-normal;
 }
 
 * {

--- a/docs/src/static/styles/index.scss
+++ b/docs/src/static/styles/index.scss
@@ -69,7 +69,7 @@ a {
 /*end visited class*/
 
 .documentBody {
-    width: calc(100% - 260px);
+    width: calc(100% - 310px);
     float: right;
 }
 
@@ -104,6 +104,6 @@ button {
 /* Scrollbar styling end*/
 @media screen and (min-width: 767px) and (max-width: 1024px) {
     .documentBody {
-        width: calc(100% - 210px);
+        width: calc(100% - 260px);
     }
 }

--- a/docs/src/static/styles/variables.scss
+++ b/docs/src/static/styles/variables.scss
@@ -12,3 +12,6 @@ $disabledcolor: #a5acb9;
 $header-zIndex: 99;
 $font-weight-normal: 300;
 $font-weight-bold: 500;
+$line-height-normal: 31px;
+$line-height-button: 16px;
+$line-height-doc: 1.6rem;

--- a/docs/src/static/styles/variables.scss
+++ b/docs/src/static/styles/variables.scss
@@ -15,3 +15,8 @@ $font-weight-bold: 500;
 $line-height-normal: 31px;
 $line-height-button: 16px;
 $line-height-doc: 1.6rem;
+$font-size-small: 12px;
+$font-size-normal: 14px;
+$font-size-large: 18px;
+$font-size-404: 1.25rem;
+$font-size-doc: 16px;


### PR DESCRIPTION
Ticket link -> https://thoughtspot.atlassian.net/browse/SCAL-77375
This PR contains:
- Increased left nav width by 50px.
- Changed font size of the main page to 16px.
- Set the line height to 1.6 for body text in the main page. 
- Added styling for code panels.
- Doc site non-responsive for mobile devices -> As discussed with @ayonghosh  we are not supporting the Mobile view. minimum resolution to support is iPad.
- Removed padding and margin from right side nav and added line height (As per Figma).
- Added styles for the bottom most <a> tag (id="preview-in-playground") on document to look like a button.