### PR TITLE
[SCAL-77688] - Added styling for table in doc

### DIFF
--- a/docs/src/components/Document/index.scss
+++ b/docs/src/components/Document/index.scss
@@ -19,9 +19,9 @@
         width: 100%;
     }
 
-    pre.highlight {
+    pre {
         white-space: pre-wrap;
-        background: #F8F8F8;
+        background: $code-block-color;
         padding: 20px 10px;
     }
 
@@ -30,7 +30,7 @@
         justify-content: space-between;
     }
 
-    code[data-lang]::after {
+    code[data-lang]:hover::after {
         content: attr(data-lang);
         text-transform: uppercase;
         color: $darkgrey;
@@ -39,8 +39,8 @@
     }
 
     #preview-in-playground {
-        background: #2770ef;
-        color: white;
+        background: $secondarycolor;
+        color: $white;
         font-size: $font-size-normal;
         font-weight: 300;
         padding: 5px 10px;

--- a/docs/src/components/Document/index.scss
+++ b/docs/src/components/Document/index.scss
@@ -47,6 +47,28 @@
         border: 0;
         border-radius: 2px;
     }
+
+    table {
+        border-spacing: 0;
+        border-collapse: collapse;
+    }
+
+    tr, th, td {
+        border: 1px solid $borderColor;
+    }
+
+    td {
+        padding: 10px;
+        text-align: left;
+        font-weight: $font-weight-normal;
+    }
+
+    th {
+        padding: 10px;
+        text-align: center;
+    }
+
+
 }
 
 @media screen and (min-width: 767px) and (max-width: 1024px) {

--- a/docs/src/static/styles/variables.scss
+++ b/docs/src/static/styles/variables.scss
@@ -6,6 +6,7 @@ $primarycolor: #1d232f;
 $secondarycolor: #2770ef;
 $lightgrey: #eaedf2;
 $darkgrey: #777e8b;
+$code-block-color: #F6F8FA;
 $borderColor: #c0c6cf;
 $hovercolor: rgba(113, 161, 244, 0.12);
 $disabledcolor: #a5acb9;


### PR DESCRIPTION
This PR contains:

- Styling for table in document.
- Styling for all the code blocks.
- Code language display on hover over code block (was static before).

Here is the screenshot:
![image](https://user-images.githubusercontent.com/78337774/108338467-4d72d280-71fc-11eb-9a47-a73b1b8fc6d8.png)
![Screenshot (7)](https://user-images.githubusercontent.com/78337774/108358044-3fc94700-7214-11eb-9801-fb0c4a5cf417.png)
